### PR TITLE
Fix off-by-one error for small sample sizes

### DIFF
--- a/quantile/stream.go
+++ b/quantile/stream.go
@@ -133,7 +133,7 @@ func (s *Stream) Query(q float64) float64 {
 		if l == 0 {
 			return 0
 		}
-		i := int(float64(l) * q + 0.5) // Add 0.5 because casting float to int always rounds down.
+		i := int(math.Ceil(float64(l) * q))
 		if i > 0 {
 			i -= 1
 		}

--- a/quantile/stream.go
+++ b/quantile/stream.go
@@ -133,7 +133,7 @@ func (s *Stream) Query(q float64) float64 {
 		if l == 0 {
 			return 0
 		}
-		i := int(float64(l) * q)
+		i := int(float64(l) * q + 0.5) // Add 0.5 because casting float to int always rounds down.
 		if i > 0 {
 			i -= 1
 		}


### PR DESCRIPTION
In order to reproduce, add the following test to github.com/prometheus/client_golang/prometheus/summary_test.go

```
func TestSmallSampleSize(t *testing.T) {
    summary := NewSummary(SummaryOpts{})
    summary.Observe(1)
    summary.Observe(2)
    summary.Observe(3)
    summary.Observe(4)
    summary.Observe(5)
    metric := dto.Metric{}
    summary.Write(&metric)
    n := 0
    for _, expected := range []*struct {
        quantile float64
        value    float64
    }{
        {quantile: 0.5, value: 3},
        {quantile: 0.9, value: 5},
        {quantile: 0.99, value: 5},
    } {
        for _, quantile := range metric.Summary.Quantile {
            if *(quantile.Quantile) == expected.quantile {
                if *(quantile.Value) != expected.value {
                    t.Errorf("Expected %v quantile = %v, but got %v.", expected.quantile, expected.value, *(quantile.Value))
                }
                n++
            }
        }
    }
    if n != 3 {
        t.Error("Some quantiles are missing.")
    }
}
```
