### PR TITLE
Avoid iterating on maps

### DIFF
--- a/quantile/stream.go
+++ b/quantile/stream.go
@@ -77,15 +77,20 @@ func NewHighBiased(epsilon float64) *Stream {
 // is guaranteed to be within (Quantile±Epsilon).
 //
 // See http://www.cs.rutgers.edu/~muthu/bquant.pdf for time, space, and error properties.
-func NewTargeted(targets map[float64]float64) *Stream {
+func NewTargeted(targetMap map[float64]float64) *Stream {
+	// Convert map to slice to avoid slow iterations on a map.
+	// ƒ is called on the hot path, so converting the map to a slice
+	// beforehand results in significant CPU savings.
+	targets := targetMapToSlice(targetMap)
+
 	ƒ := func(s *stream, r float64) float64 {
 		var m = math.MaxFloat64
 		var f float64
-		for quantile, epsilon := range targets {
-			if quantile*s.n <= r {
-				f = (2 * epsilon * r) / quantile
+		for _, t := range targets {
+			if t.quantile*s.n <= r {
+				f = (2 * t.epsilon * r) / t.quantile
 			} else {
-				f = (2 * epsilon * (s.n - r)) / (1 - quantile)
+				f = (2 * t.epsilon * (s.n - r)) / (1 - t.quantile)
 			}
 			if f < m {
 				m = f
@@ -94,6 +99,25 @@ func NewTargeted(targets map[float64]float64) *Stream {
 		return m
 	}
 	return newStream(ƒ)
+}
+
+type target struct {
+	quantile float64
+	epsilon  float64
+}
+
+func targetMapToSlice(targetMap map[float64]float64) []target {
+	targets := make([]target, 0, len(targetMap))
+
+	for quantile, epsilon := range targetMap {
+		t := target{
+			quantile: quantile,
+			epsilon:  epsilon,
+		}
+		targets = append(targets, t)
+	}
+
+	return targets
 }
 
 // Stream computes quantiles for a stream of float64s. It is not thread-safe by


### PR DESCRIPTION
Speed up `InsertTargeted*` functions by at least 2x by avoiding
iterating on maps.

Before and after benchmark comparison:

    benchmark                                 old ns/op     new ns/op     delta
    BenchmarkInsertTargeted-4                 177           73.2          -58.64%
    BenchmarkInsertTargetedSmallEpsilon-4     322           94.6          -70.62%
    BenchmarkInsertBiased-4                   75.8          74.7          -1.45%
    BenchmarkInsertBiasedSmallEpsilon-4       563           571           +1.42%
    BenchmarkQuery-4                          7426          1118          -84.94%
    BenchmarkQuerySmallEpsilon-4              80390         12535         -84.41%

    benchmark                     old allocs     new allocs     delta
    BenchmarkInsertTargeted-4     0              0              +0.00%

    benchmark                     old bytes     new bytes     delta
    BenchmarkInsertTargeted-4     0             0             +0.00%

I considered changing the function signature and require users to pass a
slice to avoid the conversion, but I think that would inconvenience
users of this library unnecessarily.

Found by profiling the CPU time spent calculating quantiles in the
Prometheus Go client library.