### PR TITLE
Fixed format error.

### DIFF
--- a/histogram/histogram_test.go
+++ b/histogram/histogram_test.go
@@ -25,7 +25,7 @@ func TestHistogram(t *testing.T) {
 	}
 
 	if g := count(h.Bins()); g != numPoints {
-		t.Fatalf("binned %d points, wanted %d", g, numPoints)
+		t.Fatalf("binned %d points, wanted %f", g, numPoints)
 	}
 }
 


### PR DESCRIPTION
Prior to this change, histogram/histogram_test.go fails with a compile error:
```
histogram/histogram_test.go:28: T.Fatalf format %d has arg numPoints of wrong type float64
```

This resolves that issue.